### PR TITLE
Add drones and health UI

### DIFF
--- a/last_drifter.html
+++ b/last_drifter.html
@@ -16,6 +16,7 @@ Mouse: Aim<br>
 LMB: Shoot<br>
 Q/E: Cycle weapons<br>
 E: Skip story
+Avoid enemy drones!<br>
 Starting weapons: Blaster / Spread Shot / Pierce Beam
 </div>
 


### PR DESCRIPTION
## Summary
- add enemy drone spawns and AI
- track ship health and score
- display enemies, hearts and score in HUD
- update help text mentioning drones

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6840c0d9a3148323856dcd110fd93b99